### PR TITLE
Fix/little refactoring and active old disabled e2e test

### DIFF
--- a/client/app/scripts/liveblog-edit/views/main.html
+++ b/client/app/scripts/liveblog-edit/views/main.html
@@ -12,7 +12,10 @@
             <i class="svg-icon-settings"></i>
         </button>
     </div>
-    <button class="btn btn-info pull-right" type="button" translate ng-click="toggleBlogState()">{{ toggleStateText }}</button>
+    <button class="btn btn-info pull-right" type="button" translate ng-click="toggleBlogState()">
+        <span ng-if="isBlogOpened()">Archive Blog</span>
+        <span ng-if="!isBlogOpened()">Activate Blog</span>
+    </button>
 </div>
 
 <section class="main-section blogedit">
@@ -24,9 +27,9 @@
 
         <!-- editor column -->
         <div class="column column-editor">
-            <span ng-show="!disableInterfaceSwitch">
+            <span ng-show="isBlogOpened()">
                 <header>
-                    <button class="btn btn-info pull-right" ng-click="create()" translate ng-disabled="disableInterfaceSwitch">New</button>
+                    <button class="btn btn-info pull-right" ng-click="resetEditor()" translate>Reset</button>
                 </header>
                 <div class="content">
                     <div class="editor-holder">
@@ -35,12 +38,12 @@
                         </div>
                     </div>
                     <div class="actions">
-                        <button class="btn" ng-disabled="!post" translate>Save as draft</button>
+                        <button class="btn" ng-click="saveAsDraft()" translate>Save as draft</button>
                         <button class="btn btn-info" ng-click="publish()" translate>Publish</button>
                     </div>
                 </div>
             </span>
-            <span ng-show="disableInterfaceSwitch">
+            <span ng-show="!isBlogOpened()">
                 <div class="alert alert-danger margin15px" role="alert">
                     <span><strong translate>This blog is closed!</strong></span><br />
                     <span translate >No posts allowed on closed blogs. Reopen the blogs in order to make any changes</span>

--- a/client/spec/timeline_add_edit_spec.js
+++ b/client/spec/timeline_add_edit_spec.js
@@ -13,25 +13,23 @@ function randomString(maxLen) {
 
 describe('timeline add to top and edit', function() {
     beforeEach(openUrl('/#/liveblog'));
-    // NOTE: Commented because it fails everytime on test servers (not on demo server)
-    // It comes from an issue with superdesk + elasticsearch
-    // it('can add item to top of the timeline', function() {
-    //     openBlog(0);
-    //     var randomText = randomString(10);
-    //     //type the random text
-    //     element(by.css('[class="st-required st-text-block"]')).sendKeys(randomText);
-    //     //click the publish button
-    //     element(by.css('[ng-click="publish()"]')).click();
-    //     browser.waitForAngular();
-    //     //go and check the timeline
-    //     element.all(by.repeater('post in posts')).then(function(posts) {
-    //         var textElement = posts[0].element(by.css('span[medium-editable]'));
-    //         //first element should have the new entered value
-    //         textElement.getText().then(function(text) {
-    //             expect(text).toEqual(randomText);
-    //         });
-    //     });
-    // });
+    it('can add item to top of the timeline', function() {
+        openBlog(0);
+        var randomText = randomString(10);
+        //type the random text
+        element(by.css('[class="st-required st-text-block"]')).sendKeys(randomText);
+        //click the publish button
+        element(by.css('[ng-click="publish()"]')).click();
+        browser.waitForAngular();
+        //go and check the timeline
+        element.all(by.repeater('post in posts')).then(function(posts) {
+            var textElement = posts[0].element(by.css('span[medium-editable]'));
+            //first element should have the new entered value
+            textElement.getText().then(function(text) {
+                expect(text).toEqual(randomText);
+            });
+        });
+    });
     it('can edit an item on the timeline', function() {
         openBlog(2);
         var randomText = randomString(10);


### PR DESCRIPTION
1. Before I work on the drafted post feature, I wanted to reorganize the `liveblog-edit` module.  
Roughly, I set the `$scope` with `angular.extend($scope, {...});`  
It helps me to understand what belongs to the scope or not.  
I also removed a `$watch`. I think it's good to avoid it when we can. See http://www.benlesh.com/2013/10/title.html
1. I renamed the button _NEW_ above the editor by _RESET_. I think this is what it does isn't it ?
1. I reactivated an e2e test which failed before. Now it works, maybe because of an update from superdesk, or because we are now using travis. Who knows ?