### PR TITLE
multiprocessing removed from backend server

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -116,15 +116,10 @@ def get_app(config=None):
     return app
 
 if __name__ == '__main__':
-
-    import multiprocessing
-
     debug = True
     host = '0.0.0.0'
     port = int(os.environ.get('PORT', '5000'))
-    workers = multiprocessing.cpu_count() * 2 + 1
     superdesk.logger.setLevel(logging.INFO)
     superdesk.logger.addHandler(logging.StreamHandler())
-
     app = get_app()
-    app.run(host=host, port=port, debug=debug, use_reloader=debug, processes=workers)
+    app.run(host=host, port=port, debug=debug, use_reloader=debug)


### PR DESCRIPTION
Save all our problems and probably the world too

- mixed items order
- 500 when we do several requests at the same time
- mixed fields in responses

Because our dependencies are not safe for multithread.