### PR TITLE
LBSD-431 Increase version for python3-ldap

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -34,7 +34,7 @@ simplejson==3.6.5
 six==1.7.3
 statsd==3.0.1
 httmock==1.2.2
-python3-ldap==0.9.5.3
+python3-ldap==0.9.5.4
 behave==1.2.5
 wooper==0.4.1
 


### PR DESCRIPTION
The current version in requirements.txt for python3-ldap is somehow
missing and this causes Travis tests to fail. An increase should fix it