### PR TITLE
LBSD-38 Fix theme selection

### DIFF
--- a/client/app/scripts/liveblog-edit/views/settings.html
+++ b/client/app/scripts/liveblog-edit/views/settings.html
@@ -49,7 +49,7 @@
                                 <div class="form-input">
                                     <select
                                       ng-model="settings.blogPreferences.theme"
-                                      ng-options="theme as theme.name for theme in settings.availableThemes track by theme"
+                                      ng-options="theme.name as theme.name + ' ' for theme in settings.availableThemes"
                                       class="form-control">
                                     </select>
                                 </div>


### PR DESCRIPTION
It seems that for now when using ngOptions the select and label
expressions( as in select as label for value in array) can't be equal. Small hack until Angular fixes the problem.