### PR TITLE
Timeline small fixes (LBSD-11)

### DIFF
--- a/client/app/scripts/liveblog-edit/directives.js
+++ b/client/app/scripts/liveblog-edit/directives.js
@@ -179,7 +179,7 @@ define([
                                 scope.post.show_all = !scope.post.show_all;
                             },
                             removePost: function(post) {
-                                postsService.remove(post).then(function(message) {
+                                postsService.remove(angular.copy(post)).then(function(message) {
                                     notify.pop();
                                     notify.info(gettext('Post removed'));
                                 }, function() {

--- a/client/app/scripts/liveblog-edit/module.js
+++ b/client/app/scripts/liveblog-edit/module.js
@@ -77,12 +77,14 @@ define([
             openPostInEditor: function (post) {
                 function fillEditor(post) {
                     cleanEditor();
-                    $scope.currentPost = post;
+                    $scope.currentPost = angular.copy(post);
                     var items = post.groups[1].refs;
                     items.forEach(function(item) {
                         item = item.item;
-                        var data = _.extend({text: item.text}, item.meta);
-                        $scope.editor.createBlock(item.item_type, data);
+                        if (angular.isDefined(item)) {
+                            var data = _.extend({text: item.text}, item.meta);
+                            $scope.editor.createBlock(item.item_type, data);
+                        }
                     });
                 }
                 doOrAskBeforeIfEditorIsNotEmpty(fillEditor.bind(null, post));


### PR DESCRIPTION
- [x] Don't use the same post reference as in the postsList for `currentPost`
- [x] Timeline, open in the editor: check if item is defined before creating a block
- [x] Remove a post: don't let the service to update the reference of the post