### PR TITLE
Feature/cache [LBSD-541]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_script:
 
 script:
     - if [ "${TARGET}" = "server" ]; then
-        cd server && nosetests && cd .. ;
+        cd server && nosetests --all-modules && cd .. ;
       fi
     - if [ "${TARGET}" = "server" ]; then
         cd server &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
     matrix:
         - TARGET=client
         - TARGET=server
-        - TARGET=server_ldap
         - TARGET=e2e_chrome
         - TARGET=e2e_firefox
 
@@ -36,7 +35,7 @@ before_install:
       fi
 
 install:
-    - if [ "${TARGET}" = "server" ] || [ "${TARGET}" = "server_ldap" ] || [ "${TARGET}" != "${TARGET/e2e/}" ]; then
+    - if [ "${TARGET}" = "server" ] || [ "${TARGET}" != "${TARGET/e2e/}" ]; then
         cd server &&
         pip install -r requirements.txt &&
         cd .. ;
@@ -70,11 +69,6 @@ script:
     - if [ "${TARGET}" = "server" ]; then
         cd server &&
         behave --format progress2 --logging-level ERROR &&
-        cd .. ;
-      fi
-    - if [ "${TARGET}" = "server_ldap" ]; then
-        cd server &&
-        LDAP_SERVER="ldap://sourcefabric.org" LDAP_BASE_FILTER="OU=Superdesk Users,dc=sourcefabric,dc=org" behave --format progress2 --logging-level ERROR &&
         cd .. ;
       fi
     - if [ "${TARGET}" = "server" ]; then

--- a/server/app.py
+++ b/server/app.py
@@ -83,7 +83,7 @@ def get_app(config=None):
 
     # cache
     app.cache = Cache(app, config={'CACHE_TYPE': 'simple'})
-    app.blog_cache = BlogCache()
+    app.blog_cache = BlogCache(cache=app.cache)
     # mail
     app.mail = Mail(app)
 

--- a/server/app.py
+++ b/server/app.py
@@ -28,12 +28,15 @@ from raven.contrib.flask import Sentry
 from superdesk.errors import SuperdeskError, SuperdeskApiError
 from liveblog.embed import embed_blueprint
 from flask.ext.assets import Environment
+from flask.ext.cache import Cache
+from liveblog.common import BlogCache
 import flask_s3
 
 
 logger = logging.getLogger('superdesk')
 sentry = Sentry(register_signal=False, wrap_wsgi=False)
 s3 = flask_s3.FlaskS3()
+assets = Environment()
 
 
 def get_app(config=None):
@@ -78,6 +81,10 @@ def get_app(config=None):
     ])
     app.jinja_loader = custom_loader
 
+    # cache
+    app.cache = Cache(app, config={'CACHE_TYPE': 'simple'})
+    app.blog_cache = BlogCache()
+    # mail
     app.mail = Mail(app)
 
     @app.errorhandler(SuperdeskError)
@@ -112,12 +119,12 @@ def get_app(config=None):
         prefix = app.api_prefix or None
         app.register_blueprint(blueprint, url_prefix=prefix)
 
-    # embed feature
-    app.register_blueprint(embed_blueprint)
     # flask assets
-    Environment(app)
+    assets.init_app(app)
     # s3
     s3.init_app(app)
+    # embed feature
+    app.register_blueprint(embed_blueprint)
     # we can only put mapping when all resources are registered
     app.data.elastic.put_mapping(app)
 

--- a/server/apps/prepopulate/app_prepopulate_data.json
+++ b/server/apps/prepopulate/app_prepopulate_data.json
@@ -38,6 +38,7 @@
     "id_name": "-id theme default-",
     "data": {
         "name": "default-theme",
+        "label": "Default Theme",
         "version": "1.0",
         "angularModule": "liveblog.default-theme",
         "styles": [

--- a/server/liveblog/blogs/blogs.py
+++ b/server/liveblog/blogs/blogs.py
@@ -198,9 +198,15 @@ class BlogService(ArchiveService):
 
     def on_updated(self, updates, original):
         publish_blog_embed_on_s3.delay(str(original['_id']), request.url_root)
+        # invalidate cache for updated blog
+        app.blog_cache.invalidate(original.get('_id'))
+        # send notifications
         push_notification('blogs', updated=1)
 
     def on_deleted(self, doc):
+        # invalidate cache for updated blog
+        app.blog_cache.invalidate(doc.get('_id'))
+        # send notifications
         push_notification('blogs', deleted=1)
 
 

--- a/server/liveblog/client_modules/client_modules.py
+++ b/server/liveblog/client_modules/client_modules.py
@@ -1,10 +1,8 @@
 from liveblog.blogs.blogs import BlogsResource, BlogService
-from eve.utils import ParsedRequest
 from liveblog.posts.posts import PostsService, PostsResource, BlogPostsService, BlogPostsResource
 from apps.users.users import UsersResource
 from apps.users.services import UsersService
 from apps.archive.common import item_url
-from superdesk import get_resource_service
 
 
 class ClientUsersResource(UsersResource):
@@ -16,7 +14,6 @@ class ClientUsersResource(UsersResource):
     public_item_methods = ['GET']
     item_methods = ['GET']
     resource_methods = ['GET']
-
     schema = {}
     schema.update(UsersResource.schema)
 
@@ -35,7 +32,6 @@ class ClientBlogsResource(BlogsResource):
     public_item_methods = ['GET']
     item_methods = ['GET']
     resource_methods = ['GET']
-
     schema = {}
     schema.update(BlogsResource.schema)
 
@@ -54,7 +50,6 @@ class ClientPostsResource(PostsResource):
     public_item_methods = ['GET']
     item_methods = ['GET']
     resource_methods = ['GET']
-
     schema = {}
     schema.update(PostsResource.schema)
 

--- a/server/liveblog/client_modules/client_modules.py
+++ b/server/liveblog/client_modules/client_modules.py
@@ -22,11 +22,7 @@ class ClientUsersResource(UsersResource):
 
 
 class ClientUsersService(UsersService):
-    def get(self, req, lookup):
-        if req is None:
-            req = ParsedRequest()
-        docs = super().get(req, lookup)
-        return docs
+    pass
 
 
 class ClientBlogsResource(BlogsResource):
@@ -45,11 +41,7 @@ class ClientBlogsResource(BlogsResource):
 
 
 class ClientBlogsService(BlogService):
-    def get(self, req, lookup):
-        if req is None:
-            req = ParsedRequest()
-        docs = super().get(req, lookup)
-        return docs
+    pass
 
 
 class ClientPostsResource(PostsResource):
@@ -68,11 +60,7 @@ class ClientPostsResource(PostsResource):
 
 
 class ClientPostsService(PostsService):
-    def get(self, req, lookup):
-        if req is None:
-            req = ParsedRequest()
-        docs = super().get(req, lookup)
-        return docs
+    pass
 
 
 class ClientBlogPostsResource(BlogPostsResource):
@@ -92,14 +80,4 @@ class ClientBlogPostsResource(BlogPostsResource):
 
 
 class ClientBlogPostsService(BlogPostsService):
-    def get(self, req, lookup):
-        if req is None:
-            req = ParsedRequest()
-        docs = super().get(req, lookup)
-        # nest the user in the response
-        for doc in docs:
-            creator = get_resource_service('users').find_one(req=None, _id=doc.get('original_creator'))
-            # select fields that are useful
-            wanted_fields = ('first_name', 'last_name', 'display_name', 'username', 'picture_url')
-            doc['original_creator'] = {key: creator.get(key, None) for key in wanted_fields}
-        return docs
+    pass

--- a/server/liveblog/common.py
+++ b/server/liveblog/common.py
@@ -4,7 +4,6 @@ from superdesk.utc import utcnow
 from flask import current_app as app
 from superdesk.celery_app import update_key
 import unittest
-import app as app_module
 
 
 def get_user(required=False):
@@ -40,6 +39,7 @@ class BlogCache(object):
 class BlogCacheTestCase(unittest.TestCase):
 
     def test_cache(self):
+        import app as app_module
         with app_module.get_app().app_context():
             blog_cache = BlogCache()
             self.assertEqual(blog_cache.get('blog', 'key'), None)

--- a/server/liveblog/common.py
+++ b/server/liveblog/common.py
@@ -1,7 +1,6 @@
 import flask
 import superdesk
 from superdesk.utc import utcnow
-from flask import current_app as app
 from superdesk.celery_app import update_key
 import unittest
 
@@ -19,29 +18,44 @@ def update_dates_for(doc):
 
 
 class BlogCache(object):
-    ''' '''
+    ''' Manage the cache for blogs '''
+
+    def __init__(self, cache):
+        self.cache = cache
+
     def __get_blog_version(self, blog, invalidate=False):
+        '''
+        Return the blog cache version.
+        If invalidate is true, the version will be incremented
+        '''
         return update_key('%s__version' % (blog), flag=invalidate)
 
     def __create_blog_cache_key(self, blog, key):
+        ''' return a key name for the given blog and key '''
         return '%s__%s__%s' % (blog, self.__get_blog_version(blog), key)
 
     def get(self, blog, key):
-        return app.cache.get(self.__create_blog_cache_key(blog, key))
+        ''' retrieve value from the cache '''
+        return self.cache.get(self.__create_blog_cache_key(blog, key))
 
     def set(self, blog, key, value):
-        return app.cache.set(self.__create_blog_cache_key(blog, key), value)
+        ''' save value to the cache '''
+        return self.cache.set(self.__create_blog_cache_key(blog, key), value)
 
     def invalidate(self, blog):
+        ''' invalidate the cache for the given blog '''
         return self.__get_blog_version(blog, invalidate=True)
 
 
 class BlogCacheTestCase(unittest.TestCase):
 
     def test_cache(self):
+        from flask.ext.cache import Cache
         import app as app_module
         with app_module.get_app().app_context():
-            blog_cache = BlogCache()
+            from flask import current_app as app
+            cache = Cache(app, config={'CACHE_TYPE': 'simple'})
+            blog_cache = BlogCache(cache)
             self.assertEqual(blog_cache.get('blog', 'key'), None)
             blog_cache.set('blog', 'key', 'value')
             self.assertEqual(blog_cache.get('blog', 'key'), 'value')

--- a/server/liveblog/common.py
+++ b/server/liveblog/common.py
@@ -1,6 +1,8 @@
 import flask
 import superdesk
 from superdesk.utc import utcnow
+from flask import current_app as app
+from superdesk.celery_app import update_key
 
 
 def get_user(required=False):
@@ -13,3 +15,21 @@ def get_user(required=False):
 def update_dates_for(doc):
     for item in ['firstcreated', 'versioncreated']:
         doc.setdefault(item, utcnow())
+
+
+class BlogCache(object):
+
+    def __get_blog_version(self, blog, invalidate=False):
+        return update_key('%s__version' % (blog), flag=invalidate)
+
+    def __create_blog_cache_key(self, blog, key):
+        return '%s__%s__%s' % (blog, self.__get_blog_version(blog), key)
+
+    def get(self, blog, key):
+        return app.cache.get(self.__create_blog_cache_key(blog, key))
+
+    def set(self, blog, key, value):
+        return app.cache.set(self.__create_blog_cache_key(blog, key), value)
+
+    def invalidate(self, blog):
+        return self.__get_blog_version(blog, invalidate=True)

--- a/server/liveblog/common.py
+++ b/server/liveblog/common.py
@@ -19,7 +19,7 @@ def update_dates_for(doc):
 
 
 class BlogCache(object):
-
+    ''' '''
     def __get_blog_version(self, blog, invalidate=False):
         return update_key('%s__version' % (blog), flag=invalidate)
 

--- a/server/liveblog/common.py
+++ b/server/liveblog/common.py
@@ -3,6 +3,8 @@ import superdesk
 from superdesk.utc import utcnow
 from flask import current_app as app
 from superdesk.celery_app import update_key
+import unittest
+import app as app_module
 
 
 def get_user(required=False):
@@ -33,3 +35,15 @@ class BlogCache(object):
 
     def invalidate(self, blog):
         return self.__get_blog_version(blog, invalidate=True)
+
+
+class BlogCacheTestCase(unittest.TestCase):
+
+    def test_cache(self):
+        with app_module.get_app().app_context():
+            blog_cache = BlogCache()
+            self.assertEqual(blog_cache.get('blog', 'key'), None)
+            blog_cache.set('blog', 'key', 'value')
+            self.assertEqual(blog_cache.get('blog', 'key'), 'value')
+            blog_cache.invalidate('blog')
+            self.assertEqual(blog_cache.get('blog', 'key'), None)

--- a/server/liveblog/embed/embed_assets/scripts/liveblog-embed/resources.service.js
+++ b/server/liveblog/embed/embed_assets/scripts/liveblog-embed/resources.service.js
@@ -9,18 +9,27 @@
         return $resource(config.api_host + 'api/client_blogs/:blogId', {blogId: config.blog_id});
     }
 
-    Posts.$inject = ['$resource', 'config'];
-    function Posts($resource, config) {
+    Users.$inject = ['$resource', 'config'];
+    function Users($resource, config) {
+        return $resource(config.api_host + 'api/client_users/:userId');
+    }
+
+    Posts.$inject = ['$resource', 'config', 'users'];
+    function Posts($resource, config, users) {
         return $resource(config.api_host + 'api/client_blogs/:blogId/posts', {blogId: config.blog_id}, {
             get: {
                 transformResponse: function(posts) {
                     // decode json
                     posts = angular.fromJson(posts);
-                    // set an items property
                     posts._items.forEach(function(post) {
+                        // add all the items directly in a `items` property
                         if (angular.isDefined(post.groups[1])) {
                             post.items = post.groups[1].refs.map(function(item) {return item.item;});
                         }
+                        // replace the creator id by the user object
+                        users.get({userId: post.original_creator}, function(user) {
+                            post.original_creator = user;
+                        });
                     });
                     return posts;
                 }
@@ -29,6 +38,7 @@
     }
 
     angular.module('liveblog-embed')
+        .service('users', Users)
         .service('posts', Posts)
         .service('blogs', Blogs);
 

--- a/server/liveblog/posts/posts.py
+++ b/server/liveblog/posts/posts.py
@@ -117,7 +117,7 @@ class PostsService(ArchiveService):
         super().on_created(docs)
         # invalidate cache for updated blog
         for doc in docs:
-            app.blog_cache.invalidate(doc['blog'])
+            app.blog_cache.invalidate(doc.get('blog'))
         # send notifications
         push_notification('posts', created=True)
 

--- a/server/liveblog/posts/posts.py
+++ b/server/liveblog/posts/posts.py
@@ -8,6 +8,7 @@ from apps.archive.archive import ArchiveResource, ArchiveService
 from superdesk.services import BaseService
 from apps.content import LINKED_IN_PACKAGES
 from superdesk.celery_app import update_key
+from flask import current_app as app
 import flask
 from superdesk.utc import utcnow
 
@@ -114,6 +115,10 @@ class PostsService(ArchiveService):
 
     def on_created(self, docs):
         super().on_created(docs)
+        # invalidate cache for updated blog
+        for doc in docs:
+            app.blog_cache.invalidate(doc['blog'])
+        # send notifications
         push_notification('posts', created=True)
 
     def on_update(self, updates, original):
@@ -128,6 +133,9 @@ class PostsService(ArchiveService):
 
     def on_updated(self, updates, original):
         super().on_updated(updates, original)
+        # invalidate cache for updated blog
+        app.blog_cache.invalidate(original.get('blog'))
+        # send notifications
         if updates.get('deleted', False):
             push_notification('posts', deleted=True, post_id=original.get('_id'))
         elif updates.get('post_status') == 'draft':
@@ -146,6 +154,9 @@ class PostsService(ArchiveService):
 
     def on_deleted(self, doc):
         super().on_deleted(doc)
+        # invalidate cache for updated blog
+        app.blog_cache.invalidate(doc.get('blog'))
+        # send notifications
         push_notification('posts', deleted=True)
 
 

--- a/server/liveblog/themes/themes.py
+++ b/server/liveblog/themes/themes.py
@@ -70,19 +70,34 @@ class ThemesService(BaseService):
             return doc
 
     def update_registered_theme_with_local_files(self):
-            for theme in self.get_local_themes_packages():
-                previous_theme = self.find_one(req=None, name=theme.get('name'))
-                if previous_theme:
-                    self.replace(previous_theme['_id'], theme, previous_theme)
-                else:
-                    self.create([theme])
+        created = []
+        updated = []
+        for theme in self.get_local_themes_packages():
+            previous_theme = self.find_one(req=None, name=theme.get('name'))
+            if previous_theme:
+                print(previous_theme)
+                self.replace(previous_theme['_id'], theme, previous_theme)
+                updated.append(theme)
+            else:
+                self.create([theme])
+                created.append(theme)
+        return (created, updated)
 
 
 class ThemesCommand(superdesk.Command):
 
     def run(self):
         theme_service = get_resource_service('themes')
-        theme_service.update_registered_theme_with_local_files()
+        created, updated = theme_service.update_registered_theme_with_local_files()
+        print('%d themes registered' % (len(created) + len(updated)))
+        if created:
+            print('added:')
+            for theme in created:
+                print('\t+ %s %s (%s)' % (theme['label'], theme['version'], theme['name']))
+        if updated:
+            print('updated:')
+            for theme in updated:
+                print('\t* %s %s (%s)' % (theme['label'], theme['version'], theme['name']))
 
 
 superdesk.command('register_local_themes', ThemesCommand())

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,3 +1,4 @@
+Flask-Cache==0.13.1
 Flask-Assets==0.10
 jsmin==2.1.1
 # Flask-S3 with support for python3


### PR DESCRIPTION
- Introduces a new class `BlogCache` to access the cache associated to a blog
- Uses Flask-Cache as interface to the cache system.  
  For now we are using SimpleCache, a simple memory cache from [werkzeug](http://werkzeug.pocoo.org/docs/0.10/contrib/cache/#werkzeug.contrib.cache.SimpleCache)
- Dissociates user information from posts to not make the cache more complex
- Remove server_ldap from travis tests