### PR TITLE
Fix/settings cleaned

### DIFF
--- a/client/app/scripts/liveblog-settings/module.js
+++ b/client/app/scripts/liveblog-settings/module.js
@@ -50,6 +50,11 @@
                 controller: LiveblogSettingsController,
                 templateUrl: 'scripts/liveblog-settings/views/general.html',
                 category: superdesk.MENU_SETTINGS
+            })
+            .activity('/settings/', {
+                label: gettext('Liveblog'),
+                controller: LiveblogSettingsController,
+                templateUrl: 'scripts/liveblog-settings/views/general.html'
             });
     }])
     .config(['apiProvider', function(apiProvider) {

--- a/client/app/styles/less/liveblog.less
+++ b/client/app/styles/less/liveblog.less
@@ -46,6 +46,8 @@
 
 // Hide the link to desks in the menu.
 // Needed since we import superdesk.desks in the modules
-#main-menu .content > ul > li > a[href="#/desks/"] {
-    display: none;
+#main-menu .content > ul > li > a[href="#/desks/"],
+.nav-tabs > li > a[href="#/settings/desks"],
+.nav-tabs > li > a[href="#/settings/user-roles"] {
+    display: none !important;
 }


### PR DESCRIPTION
This PR removes `user-roles` and `desks` tabs from settings and set the `liveblog` one as default when the user arrives in settings.