### PR TITLE
LBSD-593 User should only be able to publish an article one time

### DIFF
--- a/client/app/scripts/liveblog-edit/module.js
+++ b/client/app/scripts/liveblog-edit/module.js
@@ -89,6 +89,7 @@ define([
                 });
             },
             publish: function() {
+                $scope.publishDisabled = true;
                 notify.info(gettext('Saving post'));
                 postsService.savePost(blog._id,
                     $scope.currentPost,
@@ -98,9 +99,11 @@ define([
                     notify.pop();
                     notify.info(gettext('Post saved'));
                     cleanEditor();
+                    $scope.publishDisabled = false;
                 }, function() {
                     notify.pop();
                     notify.error(gettext('Something went wrong. Please try again later'));
+                    $scope.publishDisabled = false;
                 });
             },
             // retrieve draft panel status from url

--- a/client/app/scripts/liveblog-edit/views/main.html
+++ b/client/app/scripts/liveblog-edit/views/main.html
@@ -58,7 +58,7 @@
                     </div>
                     <div class="actions">
                         <button class="btn" ng-click="saveAsDraft()" ng-disabled="isCurrentPostPublished()" translate>Save draft</button>
-                        <button class="btn btn-info" ng-click="publish()" ng-switch="isCurrentPostPublished()">
+                        <button class="btn btn-info" ng-disabled="publishDisabled" ng-click="publish()" ng-switch="isCurrentPostPublished()">
                             <span ng-switch-when="true"  translate>Update</span>
                             <span ng-switch-when="false" translate>Publish</span>
                         </button>


### PR DESCRIPTION
When publishing a post, the "PUBLISH" button should get disabled after
the user clicks on it for the first time. Currently, the user can
publish the same post multiple times to the timeline by repeatedly
clicking on the "PUBLISH" button while the first request is still
processing.