### PR TITLE
LBSD-828 Disable draft button if not owner

### DIFF
--- a/client/app/scripts/liveblog-edit/module.js
+++ b/client/app/scripts/liveblog-edit/module.js
@@ -86,7 +86,6 @@ define([
             actionDisabled: true,
             sticky: false,
             highlight: false,
-            showDraft:true,
             actionStatus: function() {
                 return $scope.actionDisabled || $scope.actionPending;
             },
@@ -99,11 +98,14 @@ define([
             toggleHighlight: function() {
                 $scope.highlight = !$scope.highlight;
             },
-            openPostInEditor: function (post) {
-                if (post.original_creator != session.identity._id){
-                    // console.log('here', showDraft)
-                    $scope.showDraft = !$scope.showDraft;
+            showSaveAsDraft: function() {
+                if (angular.isDefined($scope.currentPost)) {
+                    return $scope.currentPost.original_creator === session.identity._id;
+                } else {
+                    return true;
                 }
+            }, 
+            openPostInEditor: function (post) {
                 function fillEditor(post) {
                     cleanEditor(false);
                     $scope.currentPost = angular.copy(post);

--- a/client/app/scripts/liveblog-edit/views/main.html
+++ b/client/app/scripts/liveblog-edit/views/main.html
@@ -163,7 +163,7 @@
                                     <span ng-switch-when="false" translate>Publish</span>
                                 </button></div>
                                 <div style="display:table-cell"><button class="btn" ng-click="saveAsContribution()" ng-disabled="isCurrentPostPublished() || actionStatus()" translate>Submit</button></div>
-                                <div ng-if="showDraft" style="display:table-cell"><button class="btn" ng-click="saveAsDraft()" ng-disabled="isCurrentPostPublished() || actionStatus()" translate>Save draft</button></div>
+                                <div style="display:table-cell"><button class="btn" ng-click="saveAsDraft()" ng-disabled="isCurrentPostPublished() || actionStatus() || !showSaveAsDraft()" translate>Save draft</button></div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Draft button should be disabled or hidden when a user opens a
contribution created by another user